### PR TITLE
More performance improvements - moving calculation of bonds next to atom...

### DIFF
--- a/MetFragNET/Fragmentation/BondEnergies.cs
+++ b/MetFragNET/Fragmentation/BondEnergies.cs
@@ -97,15 +97,17 @@ namespace MetFragNET.Fragmentation
 		private static double Lookup(string atom1, string atom2, string order)
 		{
 			var inOrderBondDesc = BondDescription(atom1, atom2, order);
-			if (energies.ContainsKey(inOrderBondDesc))
+
+			var bondEnergy = 0.0;
+			if (energies.TryGetValue(inOrderBondDesc, out bondEnergy))
 			{
-				return energies[inOrderBondDesc];
+				return bondEnergy;
 			}
 
 			var reversedBondDesc = BondDescription(atom2, atom1, order);
-			if (energies.ContainsKey(reversedBondDesc))
+			if (energies.TryGetValue(reversedBondDesc, out bondEnergy))
 			{
-				return energies[reversedBondDesc];
+				return bondEnergy;
 			}
 
 			//not a covalent bond? just assume a C-C bond TODO!

--- a/MetFragNET/Fragmentation/Fragmenter.cs
+++ b/MetFragNET/Fragmentation/Fragmenter.cs
@@ -533,11 +533,11 @@ namespace MetFragNET.Fragmentation
 		{
 			var isomorph = false;
 
+			List<IAtomContainer> fragsToCompare = null;
+			
 			//iterate over list to check for isomorphism
-			if (sumformulaToFragMap.ContainsKey(currentSumFormula))
+			if (sumformulaToFragMap.TryGetValue(currentSumFormula, out fragsToCompare))
 			{
-				var fragsToCompare = sumformulaToFragMap[currentSumFormula];
-
 				isomorph = identicalAtoms(fragment, fragsToCompare);
 
 				if (isomorph)
@@ -610,9 +610,11 @@ namespace MetFragNET.Fragmentation
 		private void addFragmentToListMap(IAtomContainer frag, String currentSumFormula)
 		{
 			//add sum formula molecule comb. to map
-			if (sumformulaToFragMap.ContainsKey(currentSumFormula))
+			List<IAtomContainer> tempList = null;
+
+			if (sumformulaToFragMap.TryGetValue(currentSumFormula, out tempList))
 			{
-				var tempList = sumformulaToFragMap[currentSumFormula];
+				tempList = tempList.ToList();
 				tempList.Add(frag);
 				sumformulaToFragMap[currentSumFormula] = tempList;
 			}
@@ -635,9 +637,11 @@ namespace MetFragNET.Fragmentation
 		private void addFragmentToListMapReplace(IAtomContainer frag, String currentSumFormula)
 		{
 			//add sum formula molecule comb. to map
-			if (sumformulaToFragMap.ContainsKey(currentSumFormula))
+			List<IAtomContainer> tempList = null;
+
+			if (sumformulaToFragMap.TryGetValue(currentSumFormula, out tempList))
 			{
-				var tempList = sumformulaToFragMap[currentSumFormula].ToList();
+				tempList = tempList.ToList();
 				tempList.Clear();
 				tempList.Add(frag);
 				sumformulaToFragMap[currentSumFormula] = tempList;

--- a/MetFragNET/Tools/MolecularFormulaTools.cs
+++ b/MetFragNET/Tools/MolecularFormulaTools.cs
@@ -153,9 +153,9 @@ namespace MetFragNET.Tools
 
 			foreach (var element in neutralLossFormulaMap.Keys)
 			{
-				if (originalFormulaMap.ContainsKey(element))
+				var massElementOrig = 0.0;
+				if (originalFormulaMap.TryGetValue(element, out massElementOrig))
 				{
-					var massElementOrig = originalFormulaMap[element];
 					var massNeutralLoss = neutralLossFormulaMap[element];
 					if ((massElementOrig - massNeutralLoss) < 0)
 					{


### PR DESCRIPTION
...s to a single place (so we don't loop over the bonds in a molecule multiple times), and removing some integer parsing that was un-needed
