### PR TITLE
Properly implement the option to not break aromatic bonds

### DIFF
--- a/MetFragNET/Algorithm/FragmentGenerator.cs
+++ b/MetFragNET/Algorithm/FragmentGenerator.cs
@@ -20,7 +20,7 @@ namespace MetFragNET.Algorithm
 
 		public IEnumerable<IAtomContainer> GenerateFragments(IAtomContainer compound, string compoundId, CancellationToken isCancelled)
 		{
-			var fragmenter = new Fragmenter(spectrum.Peaks.ToList(), config);
+			var fragmenter = new Fragmenter(spectrum.Peaks.ToList(), config, false);
 
 			// This might throw an OutOfMemoryException, but I want it to be thrown not silently fail
 			return fragmenter.GenerateFragmentsEfficient(compound, true, config.TreeDepth, compoundId, isCancelled);

--- a/MetFragNET/Fragmentation/Fragmenter.cs
+++ b/MetFragNET/Fragmentation/Fragmenter.cs
@@ -39,11 +39,13 @@ namespace MetFragNET.Fragmentation
 		private IAtomContainer originalMolecule;
 		private PostProcessor pp;
 		private double protonMass = MolecularFormulaTools.GetMonoisotopicMass("H1");
+        private readonly bool breakAromaticRings;
 
-		public Fragmenter(IList<Peak> peakList, FragmentationConfig config)
+        public Fragmenter(IList<Peak> peakList, FragmentationConfig config, bool breakAromaticRings)
 		{
 			this.peakList = peakList;
 			this.config = config;
+            this.breakAromaticRings = breakAromaticRings;
 
 			SetMinWeight();
 			ReadInNeutralLosses();
@@ -219,6 +221,17 @@ namespace MetFragNET.Fragmentation
 			foreach (var bond in atomContainer.bonds().ToWindowsEnumerable<IBond>())
 			{
 				var isTerminal = false;
+
+
+                //lets see if it is a ring and aromatic
+                //don't split up aromatic rings...see constructor for option
+                if (!breakAromaticRings)
+                {
+                    if (aromaticBonds.Contains(bond))
+                    {
+                        continue;
+                    }
+                }
 
 				// lets see if it is a terminal bond...we dont want to split up the hydrogen
 				foreach (var atom in bond.atoms().ToWindowsEnumerable<IAtom>())

--- a/MetFragNETTests/NldMetFragTests.cs
+++ b/MetFragNETTests/NldMetFragTests.cs
@@ -167,7 +167,7 @@ namespace MetFragNETTests
 			var results = fragger.metFrag(TestConfig.ExactMass, peaksToUse, TestConfig.Mode, TestConfig.MzAbs, TestConfig.MzPpm, CancellationToken.None).ToList();
 
 			Assert.That(results.Count, Is.EqualTo(4));
-			Assert.That(results[0].FragmentPics.Count(), Is.EqualTo(4));
+			Assert.That(results[0].FragmentPics.Count(), Is.EqualTo(1));
 			Assert.That(results[1].FragmentPics.Count(), Is.EqualTo(4));
 			Assert.That(results[2].FragmentPics.Count(), Is.EqualTo(4));
 			Assert.That(results[3].FragmentPics.Count(), Is.EqualTo(4));
@@ -280,7 +280,7 @@ namespace MetFragNETTests
 			Assert.That(results.Count, Is.EqualTo(4));
 			Assert.That(results[0].FragmentPics.Count(), Is.EqualTo(15));
 			Assert.That(results[1].FragmentPics.Count(), Is.EqualTo(4));
-			Assert.That(results[2].FragmentPics.Count(), Is.EqualTo(13));
+			Assert.That(results[2].FragmentPics.Count(), Is.EqualTo(5));
 			Assert.That(results[3].FragmentPics.Count(), Is.EqualTo(6));
 		}
 

--- a/MetFragNETTests/PolarityTests.cs
+++ b/MetFragNETTests/PolarityTests.cs
@@ -48,14 +48,11 @@ namespace MetFragNETTests
 
 			Assert.That(results.Count, Is.EqualTo(1));
 			var frags = results[0].FragmentPics.ToList();
-			Assert.That(frags.Count, Is.EqualTo(7));
-			Assert.That(frags[0], new FragConstraint("C10H13NO2", "", 179.0946));
-			Assert.That(frags[1], new FragConstraint("C9H10N", "+H", 133.0891));
-			Assert.That(frags[2], new FragConstraint("C9H8O", "+H", 133.0653));
-			Assert.That(frags[3], new FragConstraint("C8H7NO", "", 133.0528));
-			Assert.That(frags[4], new FragConstraint("C8H10N", "+H", 121.0891));			 
-			Assert.That(frags[5], new FragConstraint("C8H11N", "", 121.0891));
-			Assert.That(frags[6], new FragConstraint("C7H6O2", "-H", 121.029));
+			Assert.That(frags.Count, Is.EqualTo(4));
+			Assert.That(frags[0], new FragConstraint("C10H13NO2", "", 179.0946));			
+			Assert.That(frags[1], new FragConstraint("C9H8O", "+H", 133.0653));
+			Assert.That(frags[2], new FragConstraint("C8H7NO", "", 133.0528));
+			Assert.That(frags[3], new FragConstraint("C7H6O2", "-H", 121.029));
 		}
 	}
 }


### PR DESCRIPTION
This restores the bits of source code that actually act on the aromatic bonds collection built during molecule preprocessing.