### PR TITLE
Case 6407: Account for behaviour differences in ring detection betwee…

### DIFF
--- a/MetFragNET/MetFragNET.csproj
+++ b/MetFragNET/MetFragNET.csproj
@@ -43,6 +43,10 @@
     <Reference Include="IKVM.OpenJDK.Core">
       <HintPath>..\AssemblyReferences\IKVM.OpenJDK.Core.dll</HintPath>
     </Reference>
+    <Reference Include="IKVM.Runtime, Version=7.2.4630.5, Culture=neutral, PublicKeyToken=13235d27fcbfff58, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\AssemblyReferences\IKVM.Runtime.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
…n versions of CDK

The previous version used a timeout and maximum ring size limits and left the molecule half-baked if the limits were exceeded. The new version uses a threshold value calibrated using the PubChem database - you specify the percentage of molecules in that database that you can be certain the computation will complete - but more importantly, throws an exception if the limits are exceeded. Assuming it previously returned unreliable results (due to the ring detection being aborted part-way), I've decided to return an empty result with the new version.
The remaining deprecation warnings concern the CDKHueckelAromaticityDetector and AromaticityCalculator classes which, while deprecated, do not seem to have a different exception behaviour, and so shouldn't cause the fragmentation process to blow up on compounds for which it previously completed.